### PR TITLE
Link Travis CI with Code Climate for test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=4c44ebc63eb1efdc2319eb5d1f860233955614dce8b798c461373bf0aea3b990
 language: python
 python:
   - "3.6"
@@ -5,7 +8,12 @@ install:
   - pip install -r requirements.txt
 before_script:
   - cp config.yml.example config.yml
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - pytest
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 notifications:
   email: false


### PR DESCRIPTION
Links the Travis CI test runner to output the report or whatever into Code Climate so that that side of things can have one less part "missing"