### PR TITLE
Move CC_TEST_REPORTER_ID to see if it will push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_script:
 script:
   - pytest
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build -t coverage --exit-code $TRAVIS_TEST_RESULT
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-env:
-  global:
-    - CC_TEST_REPORTER_ID=4c44ebc63eb1efdc2319eb5d1f860233955614dce8b798c461373bf0aea3b990
 language: python
 python:
   - "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ iso8601
 pytest
 pyyaml
 requests
+coverage


### PR DESCRIPTION
Not seeing results show up in Code Climate with the key being
where it is, so seeing if shifting it to another location will
help coverage reporter update information.

Still, Code Climate does not consider CC_TEST_REPORTER_ID sensitive in the first place